### PR TITLE
Update class-login.php

### DIFF
--- a/src/wp-includes/class-login.php
+++ b/src/wp-includes/class-login.php
@@ -88,7 +88,9 @@ class Login {
 		}
 
 		// Check for bots.
-		$user_agent = filter_input( INPUT_SERVER, 'HTTP_USER_AGENT' );
+		// Use the null coalescing operator to ensure $user_agent is always a string.
+		// This prevents passing null to strpos, which is deprecated in newer PHP versions.
+		$user_agent = filter_input( INPUT_SERVER, 'HTTP_USER_AGENT' ) ?? '';
 		$bot        = false !== strpos( $user_agent, 'bot' );
 		if ( $bot ) {
 			return $user_id;


### PR DESCRIPTION
In php 8.1+, error `strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated` is thrown periodically.  This patch uses the null coalescing operator to ensure $user_agent is always a string.